### PR TITLE
Include better provenance; update to 0.0.6

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.0.5
+    0.0.6
 
 owners:
     [msneddon]

--- a/lib/AssemblyUtil/AssemblyUtilImpl.py
+++ b/lib/AssemblyUtil/AssemblyUtilImpl.py
@@ -263,7 +263,9 @@ class AssemblyUtil:
 
                 input_directory=input_directory,
                 workspace_name=params['workspace_name'],
-                assembly_name=params['assembly_name']
+                assembly_name=params['assembly_name'],
+
+                provenance=ctx.provenance()
             )
 
 #                    taxon_reference = None, 


### PR DESCRIPTION
Provenance previously was not using the autogenerated SDK version.