### PR TITLE
Fixing export_as_fasta function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,16 @@
 
-1.2.2: adding AnnotatedMetagenomeAssembly functionality to get_fastas function
+## 1.2.3
+### Fixed
+	- Bug fix for export_as_fasta
 
-1.2.1: Added get_fastas function in AssemblyUtilImpl
+## 1.2.2:
+### Feature
+	- adding AnnotatedMetagenomeAssembly functionality to get_fastas function
 
-1.1.0: Update to Python 3
+## 1.2.1:
+### Feature
+	- Added get_fastas function in AssemblyUtilImpl
+
+## 1.1.0:
+### Update
+	- Update to Python 3

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    1.2.2
+    1.2.3
 
 owners:
     [jjeffryes, jkbaumohl, cnelson, slebras]

--- a/lib/AssemblyUtil/AssemblyToFasta.py
+++ b/lib/AssemblyUtil/AssemblyToFasta.py
@@ -16,14 +16,14 @@ class AssemblyToFasta:
         self.dfu = DataFileUtil(callback_url)
 
 
-    def export_as_fasta(self, ctx, params):
+    def export_as_fasta(self, params):
         """ Used almost exclusively for download only """
         # validate parameters
         if 'input_ref' not in params:
             raise ValueError('Cannot export Assembly- not input_ref field defined.')
 
         # export to a file
-        file = self.assembly_as_fasta(ctx, {'ref': params['input_ref']})
+        file = self.assembly_as_fasta({'ref': params['input_ref']})
 
         # create the output directory and move the file there
         export_package_dir = os.path.join(self.scratch, file['assembly_name'])

--- a/lib/AssemblyUtil/AssemblyUtilImpl.py
+++ b/lib/AssemblyUtil/AssemblyUtilImpl.py
@@ -152,7 +152,7 @@ class AssemblyUtil:
         #BEGIN export_assembly_as_fasta
 
         atf = AssemblyToFasta(self.callback_url, self.sharedFolder)
-        output = atf.export_as_fasta(ctx, params)
+        output = atf.export_as_fasta(params)
 
         #END export_assembly_as_fasta
 

--- a/test/AssemblyUtil_server_test.py
+++ b/test/AssemblyUtil_server_test.py
@@ -102,8 +102,6 @@ class AssemblyUtilTest(unittest.TestCase):
                                                         })
         pprint(result)
         self.check_fasta_file(ws_obj_name, fasta_path)
-        return
-
 
         print('attempting upload through shock')
         data_file_cli = DataFileUtil(os.environ['SDK_CALLBACK_URL'])

--- a/test/assembly_util_get_fastas_tests.py
+++ b/test/assembly_util_get_fastas_tests.py
@@ -278,6 +278,7 @@ class AssemblyUtil_FastaTest(unittest.TestCase):
 
     # @unittest.skip('skip')
     def test_genome_input(self):
+        # NOTE: This workspace is not public. Cannot test.
         ref_list = {"ref_lst": ["27079/16/1"]}
         ret = self.getImpl().get_fastas(self.getContext(), ref_list)[0]
         self._assert_inputs(ret, ref_list)
@@ -285,6 +286,7 @@ class AssemblyUtil_FastaTest(unittest.TestCase):
 
     # @unittest.skip('skip')
     def test_annotations_assembly_input(self):
+        # NOTE: One or more of these workspaces is not public. Cannot test.
         ref_list = {"ref_lst": ["27079/3/1", "23594/10/1"]}
         ret = self.getImpl().get_fastas(self.getContext(), ref_list)[0]
         self._assert_inputs(ret, ref_list)


### PR DESCRIPTION
Export as Fasta function not working on appdev.
Somewhere a change was made and tests didn't catch check.

changes should be caught after this RP

branch not ideal but fix is kinda urgent.### 