### PR TITLE
Make repeated tests pass

### DIFF
--- a/.github/workflows/kb_sdk_test.yaml
+++ b/.github/workflows/kb_sdk_test.yaml
@@ -2,9 +2,9 @@ name: KBase SDK Tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, develop ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, develop ]
 
 jobs:
 

--- a/lib/AssemblyUtil/AssemblyToFasta.py
+++ b/lib/AssemblyUtil/AssemblyToFasta.py
@@ -20,14 +20,15 @@ class AssemblyToFasta:
         """ Used almost exclusively for download only """
         # validate parameters
         if 'input_ref' not in params:
-            raise ValueError('Cannot export Assembly- not input_ref field defined.')
+            raise ValueError('Cannot export Assembly- no input_ref field defined.')
 
         # export to a file
         file = self.assembly_as_fasta({'ref': params['input_ref']})
 
         # create the output directory and move the file there
+        # TODO might be better practice to make a temp dir rather than using the root scratch
         export_package_dir = os.path.join(self.scratch, file['assembly_name'])
-        os.makedirs(export_package_dir)
+        os.makedirs(export_package_dir, exist_ok=True)
         shutil.move(file['path'], os.path.join(export_package_dir, os.path.basename(file['path'])))
 
         # package it up and be done


### PR DESCRIPTION
After the first test run, all further runs fail because a directory used in a test already exists and the directory creation routine balks. CI tests and actually running the app should be unaffected since the tmp dir should be clear on start.