### PR TITLE
Remove ftp_url parameter for fasta upload

### DIFF
--- a/AssemblyUtil.spec
+++ b/AssemblyUtil.spec
@@ -98,7 +98,7 @@ module AssemblyUtil {
 
     /*
         Options supported:
-            file / shock_id / ftp_url - mutualy exclusive parameters pointing to file content
+            file / shock_id - mutually exclusive parameters pointing to file content
             workspace_name - target workspace
             assembly_name - target object name
 
@@ -121,7 +121,6 @@ module AssemblyUtil {
     typedef structure {
         FastaAssemblyFile file;
         ShockNodeId shock_id;
-        string ftp_url;
 
         string workspace_name;
         string assembly_name;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,8 @@
+## 2.0.0
+### Update
+    - removed the unused UI import apps.
+    - removed the `ftp_url` parameter from `save_assembly_from_fasta`
+
 ## 1.2.6
 ### Update
 	- Added unit test for error message

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,8 +8,8 @@ service-language:
     python
 
 module-version:
-    1.2.6
+    2.0.0
 
 owners:
-    [jjeffryes, jkbaumohl, cnelson, slebras, zimingy]
+    [jkbaumohl, zimingy, gaprice]
 

--- a/lib/AssemblyUtil/AssemblyUtilImpl.py
+++ b/lib/AssemblyUtil/AssemblyUtilImpl.py
@@ -27,9 +27,9 @@ class AssemblyUtil:
     # state. A method could easily clobber the state set by another while
     # the latter method is running.
     ######################################### noqa
-    VERSION = "1.2.3"
-    GIT_URL = "git@github.com:kbaseapps/AssemblyUtil.git"
-    GIT_COMMIT_HASH = "56ea7818e13cc38dadd74e52d4377070a488d74c"
+    VERSION = "2.0.0"
+    GIT_URL = "https://github.com/kbaseapps/AssemblyUtil"
+    GIT_COMMIT_HASH = "80b6b8ce41ffff9c2d45caa3f0177278b4668429"
 
     #BEGIN_CLASS_HEADER
 
@@ -170,34 +170,33 @@ class AssemblyUtil:
         if you are trying to keep an open file handle or are trying to do things concurrently to that file,
         this will break.  So this method is certainly NOT thread safe on the input file.
         :param params: instance of type "SaveAssemblyParams" (Options
-           supported: file / shock_id / ftp_url - mutualy exclusive
-           parameters pointing to file content workspace_name - target
-           workspace assembly_name - target object name type - should be one
-           of 'isolate', 'metagenome', (maybe 'transcriptome')
-           min_contig_length - if set and value is greater than 1, this will
-           only include sequences with length greater or equal to the
-           min_contig_length specified, discarding all other sequences
-           taxon_ref         - sets the taxon_ref if present contig_info     
-           - map from contig_id to a small structure that can be used to set
-           the is_circular and description fields for Assemblies (optional)
-           Uploader options not yet supported taxon_reference: The ws
-           reference the assembly points to.  (Optional) source: The source
-           of the data (Ex: Refseq) date_string: Date (or date range)
-           associated with data. (Optional)) -> structure: parameter "file"
-           of type "FastaAssemblyFile" -> structure: parameter "path" of
-           String, parameter "assembly_name" of String, parameter "shock_id"
-           of type "ShockNodeId", parameter "ftp_url" of String, parameter
-           "workspace_name" of String, parameter "assembly_name" of String,
-           parameter "external_source" of String, parameter
-           "external_source_id" of String, parameter "taxon_ref" of String,
-           parameter "min_contig_length" of Long, parameter "contig_info" of
-           mapping from String to type "ExtraContigInfo" (Structure for
-           setting additional Contig information per contig is_circ - flag if
-           contig is circular, 0 is false, 1 is true, missing indicates
-           unknown description - if set, sets the description of the field in
-           the assembly object which may override what was in the fasta file)
-           -> structure: parameter "is_circ" of Long, parameter "description"
-           of String
+           supported: file / shock_id - mutually exclusive parameters
+           pointing to file content workspace_name - target workspace
+           assembly_name - target object name type - should be one of
+           'isolate', 'metagenome', (maybe 'transcriptome') min_contig_length
+           - if set and value is greater than 1, this will only include
+           sequences with length greater or equal to the min_contig_length
+           specified, discarding all other sequences taxon_ref         - sets
+           the taxon_ref if present contig_info       - map from contig_id to
+           a small structure that can be used to set the is_circular and
+           description fields for Assemblies (optional) Uploader options not
+           yet supported taxon_reference: The ws reference the assembly
+           points to.  (Optional) source: The source of the data (Ex: Refseq)
+           date_string: Date (or date range) associated with data.
+           (Optional)) -> structure: parameter "file" of type
+           "FastaAssemblyFile" -> structure: parameter "path" of String,
+           parameter "assembly_name" of String, parameter "shock_id" of type
+           "ShockNodeId", parameter "workspace_name" of String, parameter
+           "assembly_name" of String, parameter "external_source" of String,
+           parameter "external_source_id" of String, parameter "taxon_ref" of
+           String, parameter "min_contig_length" of Long, parameter
+           "contig_info" of mapping from String to type "ExtraContigInfo"
+           (Structure for setting additional Contig information per contig
+           is_circ - flag if contig is circular, 0 is false, 1 is true,
+           missing indicates unknown description - if set, sets the
+           description of the field in the assembly object which may override
+           what was in the fasta file) -> structure: parameter "is_circ" of
+           Long, parameter "description" of String
         :returns: instance of String
         """
         # ctx is the context object

--- a/lib/AssemblyUtil/FastaToAssembly.py
+++ b/lib/AssemblyUtil/FastaToAssembly.py
@@ -253,12 +253,6 @@ class FastaToAssembly:
                                                 'shock_id': params['shock_id']
                                                 })['node_file_name']
             file_path = os.path.join(input_directory, file_name)
-        elif 'ftp_url' in params:
-            print(f'Downloading file from: {params["ftp_url"]}')
-            sys.stdout.flush()
-            file_path = self.dfu.download_web_file({'file_url': params['ftp_url'],
-                                                    'download_type': 'FTP'
-                                                    })['copy_file_path']
 
         # extract the file if it is compressed
         if file_path is not None:
@@ -274,9 +268,9 @@ class FastaToAssembly:
             if key not in params:
                 raise ValueError('required "' + key + '" field was not defined')
 
-        # one and only one of either 'file', 'shock_id', or ftp_url is required
+        # one and only one of either 'file' or 'shock_id' is required
         input_count = 0
-        for key in ('file', 'shock_id', 'ftp_url'):
+        for key in ('file', 'shock_id'):
             if key in params and params[key] is not None:
                 input_count = input_count + 1
                 if key == 'file':
@@ -284,7 +278,7 @@ class FastaToAssembly:
                         raise ValueError('when specifying a FASTA file input, "path" field was not defined in "file"')
 
         if input_count == 0:
-            raise ValueError('required FASTA file as input, set as either "file", "shock_id", or "ftp_url"')
+            raise ValueError('required FASTA file as input, set as either "file" or "shock_id"')
         if input_count > 1:
-            raise ValueError('required exactly one FASTA file as input source, you set more than one of ' +
-                             'these fields: "file", "shock_id", or "ftp_url"')
+            raise ValueError('required exactly one FASTA file as input source, you set more ' +
+                             'than one of these fields: "file", "shock_id"')

--- a/test/AssemblyUtil_server_test.py
+++ b/test/AssemblyUtil_server_test.py
@@ -115,23 +115,6 @@ class AssemblyUtilTest(unittest.TestCase):
         pprint(result2)
         self.check_fasta_file(ws_obj_name2, fasta_path)
 
-        print('attempting upload via ftp url')
-        ftp_url = 'ftp://ftp.ensemblgenomes.org/pub/release-29/bacteria//fasta/bacteria_8_collection/acaryochloris_marina_mbic11017/dna/Acaryochloris_marina_mbic11017.GCA_000018105.1.29.dna.genome.fa.gz'
-        ws_obj_name3 = 'MyNewAssembly.3'
-        result3 = assemblyUtil.save_assembly_from_fasta(self.getContext(),
-                                                        {'ftp_url': ftp_url,
-                                                         'workspace_name': self.getWsName(),
-                                                         'assembly_name': ws_obj_name3
-                                                         })
-        pprint(result3)
-        # todo: add checks here on ws object
-
-        ws_obj_name3 = 'MyNewAssembly.3'
-        result4 = assemblyUtil.export_assembly_as_fasta(self.getContext(),
-                                                        {'input_ref': self.getWsName() + '/' + ws_obj_name3})
-        pprint(result4)
-
-
     def test_empty_file_error_message(self):
         assemblyUtil = self.getImpl()
         tmp_dir = self.__class__.cfg['scratch']


### PR DESCRIPTION
Unused in kbaseland, and since it always puts downloaded files in the scratch root, is subject to race conditions if parallelized.

There's also an argument to be made that each individual app shouldn't have its own dowload code