### PR TITLE
Clarify / clean up save_assembly_as_fasta docs

### DIFF
--- a/AssemblyUtil.spec
+++ b/AssemblyUtil.spec
@@ -97,26 +97,27 @@ module AssemblyUtil {
 
 
     /*
-        Options supported:
-            file / shock_id - mutually exclusive parameters pointing to file content
+        Required arguments:
+            Exactly one of:
+                file - a pre-existing FASTA file to import. The 'assembly_name' field in the
+                    FastaAssemblyFile object is ignored.
+                shock_id - an ID of a node in the Blobstore containing the FASTA file.
             workspace_name - target workspace
             assembly_name - target object name
 
-            type - should be one of 'isolate', 'metagenome', (maybe 'transcriptome')
+        Optional arguments:
+            
+            type - should be one of 'isolate', 'metagenome', (maybe 'transcriptome').
+                Defaults to 'Unknown'
 
-            min_contig_length - if set and value is greater than 1, this will only include sequences
-                                with length greater or equal to the min_contig_length specified, discarding
-                                all other sequences
+            min_contig_length - if set and value is greater than 1, this will only
+                include sequences with length greater or equal to the min_contig_length
+                specified, discarding all other sequences
 
-            taxon_ref         - sets the taxon_ref if present
+            taxon_ref - sets the taxon_ref if present
 
-            contig_info       - map from contig_id to a small structure that can be used to set the is_circular
-                                and description fields for Assemblies (optional)
-
-        Uploader options not yet supported
-            taxon_reference: The ws reference the assembly points to.  (Optional)
-            source: The source of the data (Ex: Refseq)
-            date_string: Date (or date range) associated with data. (Optional)
+            contig_info - map from contig_id to a small structure that can be used to set the
+                is_circular and description fields for Assemblies (optional)
     */
     typedef structure {
         FastaAssemblyFile file;
@@ -132,16 +133,9 @@ module AssemblyUtil {
 
         int min_contig_length;
 
-        mapping<string,ExtraContigInfo> contig_info; 
+        mapping<string, ExtraContigInfo> contig_info; 
 
     } SaveAssemblyParams;
 
-    /*
-        WARNING: has the side effect of moving the file to a temporary staging directory, because the upload
-        script for assemblies currently requires a working directory, not a specific file.  It will attempt
-        to upload everything in that directory.  This will move the file back to the original location, but
-        if you are trying to keep an open file handle or are trying to do things concurrently to that file,
-        this will break.  So this method is certainly NOT thread safe on the input file.
-    */
     funcdef save_assembly_from_fasta(SaveAssemblyParams params) returns (string ref) authentication required;
 };

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,7 +1,13 @@
 ## 2.0.0
 ### Update
-    - removed the unused UI import apps.
-    - removed the `ftp_url` parameter from `save_assembly_from_fasta`
+    - Removed the unused UI import apps.
+    - Removed the `ftp_url` parameter from `save_assembly_from_fasta`
+    - Clarified `save_assembly_from_fasta` documentation
+    - Fixed a bug in `save_assembly_from_fasta` that could cause file name collisions if
+      multiple `AssemblyUtil` instances are run in parallel
+    - Clarified the error message text when an empty file is submitted or results from
+      contig filtering, and prevented a guaranteed to fail attempt to save the file to the
+      Blobstore
 
 ## 1.2.6
 ### Update

--- a/lib/AssemblyUtil/AssemblyUtilImpl.py
+++ b/lib/AssemblyUtil/AssemblyUtilImpl.py
@@ -8,7 +8,6 @@ from AssemblyUtil.FastaToAssembly import FastaToAssembly
 from AssemblyUtil.AssemblyToFasta import AssemblyToFasta
 from AssemblyUtil.TypeToFasta import TypeToFasta
 from installed_clients.WorkspaceClient import Workspace
-from installed_clients.baseclient import ServerError
 
 #END_HEADER
 
@@ -30,7 +29,7 @@ class AssemblyUtil:
     ######################################### noqa
     VERSION = "2.0.0"
     GIT_URL = "https://github.com/kbaseapps/AssemblyUtil"
-    GIT_COMMIT_HASH = "80b6b8ce41ffff9c2d45caa3f0177278b4668429"
+    GIT_COMMIT_HASH = "d3d3e8ac5f7d34cad858c8679ebd096680b95d58"
 
     #BEGIN_CLASS_HEADER
 
@@ -165,26 +164,20 @@ class AssemblyUtil:
 
     def save_assembly_from_fasta(self, ctx, params):
         """
-        WARNING: has the side effect of moving the file to a temporary staging directory, because the upload
-        script for assemblies currently requires a working directory, not a specific file.  It will attempt
-        to upload everything in that directory.  This will move the file back to the original location, but
-        if you are trying to keep an open file handle or are trying to do things concurrently to that file,
-        this will break.  So this method is certainly NOT thread safe on the input file.
-        :param params: instance of type "SaveAssemblyParams" (Options
-           supported: file / shock_id - mutually exclusive parameters
-           pointing to file content workspace_name - target workspace
-           assembly_name - target object name type - should be one of
-           'isolate', 'metagenome', (maybe 'transcriptome') min_contig_length
-           - if set and value is greater than 1, this will only include
-           sequences with length greater or equal to the min_contig_length
-           specified, discarding all other sequences taxon_ref         - sets
-           the taxon_ref if present contig_info       - map from contig_id to
-           a small structure that can be used to set the is_circular and
-           description fields for Assemblies (optional) Uploader options not
-           yet supported taxon_reference: The ws reference the assembly
-           points to.  (Optional) source: The source of the data (Ex: Refseq)
-           date_string: Date (or date range) associated with data.
-           (Optional)) -> structure: parameter "file" of type
+        :param params: instance of type "SaveAssemblyParams" (Required
+           arguments: One, and only one, of: file - a pre-existing FASTA file
+           to import. The 'assembly_name' field in the FastaAssemblyFile
+           object is ignored. shock_id - an ID of a node in the Blobstore
+           containing the FASTA file. workspace_name - target workspace
+           assembly_name - target object name Optional arguments: type -
+           should be one of 'isolate', 'metagenome', (maybe 'transcriptome')
+           - defaults to 'Unknown min_contig_length - if set and value is
+           greater than 1, this will only include sequences with length
+           greater or equal to the min_contig_length specified, discarding
+           all other sequences taxon_ref - sets the taxon_ref if present
+           contig_info - map from contig_id to a small structure that can be
+           used to set the is_circular and description fields for Assemblies
+           (optional)) -> structure: parameter "file" of type
            "FastaAssemblyFile" -> structure: parameter "path" of String,
            parameter "assembly_name" of String, parameter "shock_id" of type
            "ShockNodeId", parameter "workspace_name" of String, parameter


### PR DESCRIPTION
The text blob for the function itself seems crufty and is definitely inaccurate. Currently it's perfectly fine to read from the input file while the function is running. Obviously if changes are made to the file in that time bad things will happen, but that seems completely obvious and doesn't need to be documented.

Also update release notes.

Closes #49 