### PR TITLE
Make FastaToAssembly unit testable

### DIFF
--- a/lib/AssemblyUtil/AssemblyUtilImpl.py
+++ b/lib/AssemblyUtil/AssemblyUtilImpl.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from AssemblyUtil.FastaToAssembly import FastaToAssembly
 from AssemblyUtil.AssemblyToFasta import AssemblyToFasta
 from AssemblyUtil.TypeToFasta import TypeToFasta
+from installed_clients.DataFileUtilClient import DataFileUtil
 from installed_clients.WorkspaceClient import Workspace
 
 #END_HEADER
@@ -200,8 +201,11 @@ class AssemblyUtil:
         print('save_assembly_from_fasta -- paramaters = ')
         #pprint(params)
 
-        fta = FastaToAssembly(self.callback_url, Path(self.sharedFolder), self.ws_url)
-        assembly_info = fta.import_fasta(ctx, params)
+        assembly_info = FastaToAssembly(
+            DataFileUtil(self.callback_url, token=ctx['token']),
+            Workspace(self.ws_url, token=ctx['token']),
+            Path(self.sharedFolder)
+        ).import_fasta(params)
         ref = f'{assembly_info[6]}/{assembly_info[0]}/{assembly_info[4]}'
 
         #END save_assembly_from_fasta

--- a/lib/AssemblyUtil/FastaToAssembly.py
+++ b/lib/AssemblyUtil/FastaToAssembly.py
@@ -18,12 +18,12 @@ class FastaToAssembly:
     # Note added X due to kb|g.1886.fasta
     _VALID_CHARS = "-ACGTUWSMKRYBDHVNX"
     _AMINO_ACID_SPECIFIC_CHARACTERS = "PLIFQE"
-    def __init__(self, callback_url, scratch: Path, ws_url):
+    def __init__(self, dfu: DataFileUtil, ws: Workspace, scratch: Path):
         self._scratch = scratch
-        self._dfu = DataFileUtil(callback_url)
-        self._ws = Workspace(ws_url)
+        self._dfu = dfu
+        self._ws = ws
 
-    def import_fasta(self, ctx, params):
+    def import_fasta(self, params):
         print('validating parameters')
         self._validate_params(params)
         tmpdir = self._scratch / ("import_fasta_" + str(uuid.uuid4()))


### PR DESCRIPTION
Inject dependencies rather than create them.
Also explicitly pass tokens vs. implicit passing via envvar