### PR TITLE
Batchify save assembly internals

### DIFF
--- a/lib/AssemblyUtil/AssemblyUtilImpl.py
+++ b/lib/AssemblyUtil/AssemblyUtilImpl.py
@@ -201,12 +201,11 @@ class AssemblyUtil:
         print('save_assembly_from_fasta -- paramaters = ')
         #pprint(params)
 
-        assembly_info = FastaToAssembly(
+        ref = FastaToAssembly(
             DataFileUtil(self.callback_url, token=ctx['token']),
             Workspace(self.ws_url, token=ctx['token']),
             Path(self.sharedFolder)
         ).import_fasta(params)
-        ref = f'{assembly_info[6]}/{assembly_info[0]}/{assembly_info[4]}'
 
         #END save_assembly_from_fasta
 

--- a/test/AssemblyUtil_server_test.py
+++ b/test/AssemblyUtil_server_test.py
@@ -141,7 +141,7 @@ class AssemblyUtilTest(unittest.TestCase):
 
     def test_empty_file_error_message(self):
         assemblyUtil = self.getImpl()
-        tmp_dir = self.__class__.cfg['scratch']
+        tmp_dir = self.cfg['scratch']
         file_name = "empty.FASTA"
         shutil.copy(os.path.join("data", file_name), tmp_dir)
         empty_file_path = os.path.join(tmp_dir, file_name)
@@ -155,10 +155,12 @@ class AssemblyUtilTest(unittest.TestCase):
                                                      })
             raise Exception("Wrong error message")
         except ValueError as e:
-            self.assertEqual(
+            self.assertIn(
                 'Either the original FASTA file contained no sequences or they were all '
-                + 'filtered out based on the min_contig_length parameter',
+                + 'filtered out based on the min_contig_length parameter for file '
+                + '/kb/module/work/tmp/import_fasta_',
                 str(e))
+            self.assertIn('/empty.FASTA.filtered.fa', str(e))
 
     def test_legacy_contigset_download(self):
         ws_obj_name4 = 'LegacyContigs'


### PR DESCRIPTION
These changes rewrite the save assembly code internals to operate in a
batched manner although the only public API is still for a single upload.

Next steps:
* Handle relevant TODOs for the batch code (e.g. param validation, etc)
* Add unit tests exercising the batch code and covering uncovered code
* Expose in SDK spec