### PR TITLE
Simplify main fasta import routine slightly

### DIFF
--- a/test/AssemblyUtil_server_test.py
+++ b/test/AssemblyUtil_server_test.py
@@ -107,14 +107,14 @@ class AssemblyUtilTest(unittest.TestCase):
         pprint(result)
         self.check_fasta_file(ws_obj_name, fasta_path)
 
-        print('attempting upload of gzipped file')
+        print('attempting upload of gzipped file using workspace id vs name')
         # DFU can't see the file unless it's in scratch
         shutil.copy(Path("data") / "test2.fna.gz", tmp_dir)
         result = assemblyUtil.save_assembly_from_fasta(
             self.getContext(),
             {
                 'file': {'path': str(Path(tmp_dir) / "test2.fna.gz")},
-                'workspace_name': self.ws_name,
+                'workspace_id': self.ws_id,
                 'assembly_name': 'MyNewAssembly_gzip',
                 'taxon_ref': 'ReferenceTaxons/unknown_taxon',
             })
@@ -244,7 +244,10 @@ class AssemblyUtilTest(unittest.TestCase):
         fasta_path = tmp_dir + "/" + file_name
         print('attempting upload')
         ws_obj_name = 'FilteredAssembly'
-        with self.assertRaisesRegex(ValueError, 'KBase Assembly Utils tried to save an assembly'):
+        err = ("KBase Assembly Utils tried to save an assembly, but the calling "
+               + f"application specified a file \\('{tmp_dir}/not_a_real_file.fna'\\) "
+               + "that is missing. Please check the application logs for details.")
+        with self.assertRaisesRegex(ValueError, err):
             assemblyUtil.save_assembly_from_fasta(self.getContext(),
                                                        {'file': {'path': fasta_path},
                                                         'workspace_name': self.ws_name,

--- a/test/FastaToAssembly_test.py
+++ b/test/FastaToAssembly_test.py
@@ -1,0 +1,83 @@
+'''
+Unit tests for FastaToAssembly.py.
+Integration tests are in the server test file.
+'''
+
+from pathlib import Path
+from pytest import raises
+from unittest.mock import create_autospec
+
+from AssemblyUtil.FastaToAssembly import FastaToAssembly
+from installed_clients.DataFileUtilClient import DataFileUtil
+from installed_clients.WorkspaceClient import Workspace
+from testing_helpers import assert_exception_correct
+
+
+# TODO Add more unit tests when changing things until entire file is covered by unit tests
+
+
+def _set_up_mocks(path: str = 'fake_scratch'):
+    dfu = create_autospec(DataFileUtil, spec_set=True, instance=True)
+    ws = create_autospec(Workspace, spec_set=True, instance=True)
+    fta = FastaToAssembly(dfu, ws, Path(path))
+    return fta, dfu, ws
+
+
+def _run_test_spec(test_spec):
+    fta, _, _ = _set_up_mocks()
+    for err, params in test_spec.items():
+        with raises(Exception) as got:
+            fta.import_fasta(params)
+        assert_exception_correct(got.value, ValueError(err))
+
+
+def test_workspace_name_id_input_fail():
+    '''
+    Tests the cases where workspace identifiers are submitted incorrectly.
+    '''
+    err1 = 'Exactly one of a workspace_id > 0 or a workspace_name must be provided'
+    err2 = 'workspace_id must be an integer > 0'
+    test_spec = {
+        err1: {},
+        err1: {'werksce_nme': 'foo'},
+        err1: {'workspace_name': 'bar', 'workspace_id': 1},
+        err1: {'workspace_id': 0},
+        err2: {'workspace_id': -1},
+        err2: {'workspace_id': -100},
+        'workspace_id must be an integer, got: foo': {'workspace_id': 'foo'},
+    }
+    _run_test_spec(test_spec)
+
+
+def test_no_assembly_name():
+    fta, dfu, _ = _set_up_mocks()
+    dfu.ws_name_to_id.return_value = 34
+
+    with raises(Exception) as got:
+        fta.import_fasta({'workspace_name': 'whee'})
+    assert_exception_correct(got.value, ValueError(
+        'Required parameter assembly_name was not defined'))
+
+    dfu.ws_name_to_id.assert_called_once_with('whee')
+
+
+def _update(d1, d2):
+    d = dict(d1)
+    d.update(d2)
+    return d
+
+def test_file_source_fail():
+    '''
+    Tests the case where file source (e.g. file path, shock ID) info is submitted incorrectly.
+    '''
+    err1 = 'Exactly one of file or shock_id is required'
+    err2 = 'When specifying a FASTA file input, "path" field was not defined in "file"'
+    b = {'workspace_id': 1, 'assembly_name': 'foo'}
+    test_spec = {
+        err1: b,
+        err1: _update(b, {'filet': {'path': '/foo/bar'}}),
+        err1: _update(b, {'file':  {'path': '/foo/bar'}, 'shock_id': 'fakeid'}),
+        err2: _update(b, {'file': '/foo/bar'}),
+        err2: _update(b, {'file': {'perth': '/foo/bar'}}),
+    }
+    _run_test_spec(test_spec)

--- a/test/testing_helpers.py
+++ b/test/testing_helpers.py
@@ -1,0 +1,6 @@
+import traceback
+
+def assert_exception_correct(got: Exception, expected: Exception):
+    err = "".join(traceback.TracebackException.from_exception(got).format())
+    assert got.args == expected.args, err
+    assert type(got) == type(expected)


### PR DESCRIPTION
... and simplify / improve parameter checking.

Will only accept a workspace ID for the bulk method, so moved
the translation call outside of the main method